### PR TITLE
fix: Cannot find package '@commander-js/extra-typings

### DIFF
--- a/.changeset/fair-parrots-sleep.md
+++ b/.changeset/fair-parrots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@heymp/scratchpad": patch
+---
+
+Fix cannot find package '@commander-js/extra-typings error.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "types.d.ts"
   ],
   "dependencies": {
+    "@commander-js/extra-typings": "^12.1.0",
     "commander": "^12.0.0",
     "esbuild": "^0.23.0",
     "playwright": "^1.44.1"
@@ -24,7 +25,6 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
-    "@commander-js/extra-typings": "^12.1.0",
     "@types/node": "^22.1.0",
     "typescript": "^5.5.4"
   },


### PR DESCRIPTION
This fixes the major breaking error of `Cannot find package '@commander-js/extra-typings` error when running the cli.